### PR TITLE
Fix Wallet.serialized()

### DIFF
--- a/BitcoinKit/Wallet.swift
+++ b/BitcoinKit/Wallet.swift
@@ -28,8 +28,8 @@ final public class Wallet {
 
     public func serialized() -> Data {
         var data = Data()
-        data = privateKey.raw
-        data = publicKey.raw
+        data += privateKey.raw
+        data += publicKey.raw
         return data
     }
 }


### PR DESCRIPTION
Current implementation of `serialized()` is only serializing the pubkey data.
So I fixed it.